### PR TITLE
Update HackCertificate.sol to use _requireOwned and remove _exists

### DIFF
--- a/contracts/src/HackCertificate.sol
+++ b/contracts/src/HackCertificate.sol
@@ -54,12 +54,8 @@ contract HackCertificate is ERC721, Ownable {
     }
 
     function verifyCertificate(uint256 tokenId) external view returns (Certificate memory) {
-        require(_exists(tokenId), "Certificate does not exist");
+        _requireOwned(tokenId);
         return certificates[tokenId];
-    }
-
-    function _exists(uint256 tokenId) internal view returns (bool) {
-        return _ownerOf(tokenId) != address(0);
     }
 
     function revokeCertificate(uint256 tokenId) external {

--- a/contracts/src/HackCertificate.sol
+++ b/contracts/src/HackCertificate.sol
@@ -62,7 +62,7 @@ contract HackCertificate is ERC721, Ownable {
         require(owner() == msg.sender || certificates[tokenId].issuer == msg.sender,
         "Not authorized to revoke");
         
-        require(_exists(tokenId), "Certificate does not exist");
+        _requireOwned(tokenId);
 
         delete certificates[tokenId];
 


### PR DESCRIPTION
Updates the HackCertificate.sol contract to:
- Replace `_exists` with `_requireOwned` from OpenZeppelin's ERC721 library for better standardization.
- Remove the redundant `_exists` function to simplify the code.